### PR TITLE
switch to the newer and supported utility hpssacli

### DIFF
--- a/usr/share/openmediavault/sysinfo/modules.d/31-hpraid
+++ b/usr/share/openmediavault/sysinfo/modules.d/31-hpraid
@@ -21,7 +21,7 @@ set -e
 
 . /usr/share/openmediavault/sysinfo/functions
 
-HWRAID_BIN="/usr/sbin/hpacucli"
+HWRAID_BIN="/usr/sbin/hpssacli"
 
 if [ ! -f "${HWRAID_BIN}" ]; then
     exit 0


### PR DESCRIPTION
hpssacli is available as a deb package from HP directly.
the parameters for the various commands in the plugin still stand as they were kept in the new utility.
it can be obtained from hp directly as a dependency of the omv package.
a new repo (nonfree) must be added:
/etc/apt/sources.list.d$ cat HP-mcp.list

# auto-generated by
#   http://downloads.linux.hpe.com/SDR/repo/add_repo.sh mcp

# By including and using this configuration,
# you agree to the terms and conditions
# of the HP Software License Agreement at
# http://h20000.www2.hp.com/bizsupport/TechSupport/softwareLicense.jsp?lang=en&cc=us&prodTypeId=15351&prodSeriesId=1121516&prodNameId=3288134&taskId=135

# HP Software Delivery Repository for mcp
deb http://downloads.linux.hpe.com/SDR/repo/mcp jessie/current non-free